### PR TITLE
Create Soupe

### DIFF
--- a/Cook-Folder/Soupe
+++ b/Cook-Folder/Soupe
@@ -1,0 +1,7 @@
+Ingredients
+1 pound baby portobello mushrooms, chopped
+2 tablespoons olive oil
+2 packages (6 ounces each) long grain and wild rice mix
+1 carton (32 ounces) reduced-sodium beef broth
+1/2 cup water
+2 cups heavy whipping cream


### PR DESCRIPTION
Ingredients
1 pound baby portobello mushrooms, chopped
2 tablespoons olive oil
2 packages (6 ounces each) long grain and wild rice mix
1 carton (32 ounces) reduced-sodium beef broth
1/2 cup water
2 cups heavy whipping cream